### PR TITLE
Enable secure cookies in compose.yaml

### DIFF
--- a/services/ingestor/compose.yaml
+++ b/services/ingestor/compose.yaml
@@ -126,5 +126,6 @@ configs:
         Other:
           BackendAddress: ${INGESTOR_DOMAIN}
           Port: 8080
+          SecureCookies: true​
           LogLevel: Debug
           DisableServiceAccountCheck: true


### PR DESCRIPTION
This isn't defined in the ingestor-native repository either, but is important to enable cross-site cookies.